### PR TITLE
Make connection Resource referentially transparent

### DIFF
--- a/src/test/scala/ray/fs2/ftp/SFtpTest.scala
+++ b/src/test/scala/ray/fs2/ftp/SFtpTest.scala
@@ -258,5 +258,16 @@ class SFtpTest extends AnyWordSpec with Matchers {
         case Left(ex: SFTPException) if ex.getStatusCode == StatusCode.NO_SUCH_FILE =>
       }
     }
+
+    "connect and disconect multiple times in a arow" in {
+      val ls: IO[List[FtpResource]] = connect(settings)
+        .use(
+          _.ls("/").compile.toList
+        )
+
+      fs2.Stream.repeatEval(ls).take(2).compile.toList
+        .unsafeRunSync().flatten
+        .map(_.path) should contain allElementsOf List("/notes.txt", "/dir1")
+    }
   }
 }

--- a/src/test/scala/ray/fs2/ftp/SFtpTest.scala
+++ b/src/test/scala/ray/fs2/ftp/SFtpTest.scala
@@ -16,8 +16,8 @@ import scala.io.Source
 class SFtpTest extends AnyWordSpec with Matchers {
   implicit private val ec: ExecutionContext = ExecutionContext.global
   implicit private val cs: ContextShift[IO] = IO.contextShift(ec)
-  val home = Paths.get("ftp-home/sftp/home/foo")
-  private val settings = SecureFtpSettings("127.0.0.1", port = 2222, FtpCredentials("foo", "foo"))
+  val home                                  = Paths.get("ftp-home/sftp/home/foo")
+  private val settings                      = SecureFtpSettings("127.0.0.1", port = 2222, FtpCredentials("foo", "foo"))
 
   "SFtp" should {
     "connect with invalid credentials" in {
@@ -257,8 +257,8 @@ class SFtpTest extends AnyWordSpec with Matchers {
       }
     }
 
-    "connect and disconect multiple times in a arow" in {
-      val ls: IO[List[FtpResource]] = connect(settings)
+    "connect and disconect multiple times in a row" in {
+      val ls = connect(settings)
         .use(
           _.ls("/").compile.toList
         )

--- a/src/test/scala/ray/fs2/ftp/SFtpTest.scala
+++ b/src/test/scala/ray/fs2/ftp/SFtpTest.scala
@@ -16,10 +16,8 @@ import scala.io.Source
 class SFtpTest extends AnyWordSpec with Matchers {
   implicit private val ec: ExecutionContext = ExecutionContext.global
   implicit private val cs: ContextShift[IO] = IO.contextShift(ec)
-
-  private val settings = SecureFtpSettings("127.0.0.1", port = 2222, FtpCredentials("foo", "foo"))
-
   val home = Paths.get("ftp-home/sftp/home/foo")
+  private val settings = SecureFtpSettings("127.0.0.1", port = 2222, FtpCredentials("foo", "foo"))
 
   "SFtp" should {
     "connect with invalid credentials" in {
@@ -265,8 +263,13 @@ class SFtpTest extends AnyWordSpec with Matchers {
           _.ls("/").compile.toList
         )
 
-      fs2.Stream.repeatEval(ls).take(2).compile.toList
-        .unsafeRunSync().flatten
+      fs2.Stream
+        .repeatEval(ls)
+        .take(2)
+        .compile
+        .toList
+        .unsafeRunSync()
+        .flatten
         .map(_.path) should contain allElementsOf List("/notes.txt", "/dir1")
     }
   }


### PR DESCRIPTION
Moved `val ssh = new SSHClient(settings.sshConfig)` into the Resource acquire block. SSHClient is rather unsafe because it contains Socket, InputStream and more. 