### PR TITLE
Updates for fs2 v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ project/metals.sbt
 
 .metals/
 .bloop/
+.bsp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     - &build-test
       stage: build & test
       jdk: openjdk11
-      scala: 2.13.1
+      scala: 2.13.5
       script:
         - set -e
         - docker-compose up -d
@@ -37,7 +37,7 @@ jobs:
 
     - <<: *build-test
       jdk: openjdk8
-      scala: 2.13.1
+      scala: 2.13.5
 
     - <<: *build-test
       jdk: openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala213 = "2.13.1"
+lazy val scala213 = "2.13.5"
 lazy val scala212 = "2.12.11"
 
 lazy val `fs2-ftp` = project
@@ -39,11 +39,11 @@ lazy val `fs2-ftp` = project
   )
   .settings(
     libraryDependencies ++= Seq(
-      "co.fs2"                   %% "fs2-core"                % "2.5.0",
-      "co.fs2"                   %% "fs2-io"                  % "2.5.0",
-      "org.scala-lang.modules"   %% "scala-collection-compat" % "2.3.2",
+      "co.fs2"                   %% "fs2-core"                % "3.0.3",
+      "co.fs2"                   %% "fs2-io"                  % "3.0.3",
+      "org.scala-lang.modules"   %% "scala-collection-compat" % "2.4.3",
       "com.hierynomus"           % "sshj"                     % "0.31.0",
-      "commons-net"              % "commons-net"              % "3.7.2",
+      "commons-net"              % "commons-net"              % "3.8.0",
       "org.apache.logging.log4j" % "log4j-api"                % "2.13.0" % Test,
       "org.apache.logging.log4j" % "log4j-core"               % "2.13.0" % Test,
       "org.apache.logging.log4j" % "log4j-slf4j-impl"         % "2.13.0" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.5
+sbt.version = 1.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("org.scoverage"  % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage"  % "sbt-scoverage" % "1.7.0")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"  % "2.3.4")
 addSbtPlugin("com.dwijnand"   % "sbt-dynver"    % "4.1.1")
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"       % "2.0.2")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"  % "3.9.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"  % "3.9.7")

--- a/src/main/scala/fs2/ftp/package.scala
+++ b/src/main/scala/fs2/ftp/package.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import cats.effect.{ ConcurrentEffect, ContextShift, Resource }
+import cats.effect.{ Async, Resource }
 import fs2.ftp.FtpSettings.{ SecureFtpSettings, UnsecureFtpSettings }
 
 package object ftp {
@@ -11,7 +11,7 @@ package object ftp {
    *
    * If operation failed, it emit a  `fs2.ftp.ConnectionError` with the cause of the failure
    */
-  def connect[F[_]: ContextShift: ConcurrentEffect, A](settings: FtpSettings[A]): Resource[F, FtpClient[F, A]] =
+  def connect[F[_]: Async, A](settings: FtpSettings[A]): Resource[F, FtpClient[F, A]] =
     settings match {
       case s: UnsecureFtpSettings => UnsecureFtp.connect(s)
       case s: SecureFtpSettings   => SecureFtp.connect(s)


### PR DESCRIPTION
- Updated `scala-2.13 ` from 2.13.1 to 2.13.5

*Dependencies Updates*
- Updated `fs2` dependency from 2.5.0 to 3.0.2
- Updated `scala-collection-compat` dependency from 2.3.2 to 2.4.3
- Updated `commons-net` dependency from 3.7.2 to 3.8.0

*Plugin Updates*
- Updated `sbt-scoverage` plugin from 1.6.1 to 1.7.0
- Updated `sbt-sonatype` plugin from 3.9.5 to 3.9.7