### PR TITLE
Add config for maxUnconfirmedWrites

### DIFF
--- a/src/main/scala/fs2/ftp/FtpSettings.scala
+++ b/src/main/scala/fs2/ftp/FtpSettings.scala
@@ -52,7 +52,8 @@ object FtpSettings {
     knownHosts: Option[String],
     timeOut: Int,
     connectTimeOut: Int,
-    sshConfig: SshConfig
+    sshConfig: SshConfig,
+    maxUnconfirmedWrites: Int
   ) extends FtpSettings[JSFTPClient]
 
   object SecureFtpSettings {
@@ -67,7 +68,8 @@ object FtpSettings {
         knownHosts = None,
         0,
         0,
-        new DefaultSshConfig()
+        new DefaultSshConfig(),
+        0
       )
 
     def apply(host: String, port: Int, credentials: FtpCredentials, identity: SftpIdentity): SecureFtpSettings =
@@ -80,7 +82,8 @@ object FtpSettings {
         knownHosts = None,
         0,
         0,
-        new DefaultSshConfig()
+        new DefaultSshConfig(),
+        0
       )
   }
 


### PR DESCRIPTION
Hi. We were having trouble with performance when uploading files, so we have added some config to increase the maximum number of unconfirmed writes during a transfer.

Co-authored-by: Catia Ferreira <catia.ferreira@itv.com>